### PR TITLE
Add sort-max-ram to the default DAPI descriptor

### DIFF
--- a/sapi_manifests/cnapi/template
+++ b/sapi_manifests/cnapi/template
@@ -64,6 +64,7 @@
 			               "identity"],
 			        "soft-filter-locality-hints",
 			        "sort-min-ram",
+			        "sort-max-ram",
 			        "sort-min-owner",
 			        "sort-random",
 			        "pick-weighted-random"]


### PR DESCRIPTION
This is part of joyent/sdc-designation#1, see the additional info there.

Enables users to choose a 'emptiest server first' allocation policy (by changing server_spread to 'max-ram') if they want it.