### PR TITLE
Convert overprovision_ratios back to numbers when reading

### DIFF
--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -1084,8 +1084,12 @@ ModelServer.prototype.getFinal = function (callback) {
         },
         function (cb) {
             if (server.overprovision_ratios) {
-                server.overprovision_ratios =
-                    qs.parse(server.overprovision_ratios);
+                var v = qs.parse(server.overprovision_ratios);
+                /* values come out of qs.parse as strings, our contract is numbers */
+                Object.keys(v).forEach(function(k) {
+                    v[k] = +v[k];
+                });
+                server.overprovision_ratios = v;
             } else {
                 delete server.overprovision_ratios;
             }


### PR DESCRIPTION
Otherwise dapi will error out because it can't process a bunch of strings.