### PR TITLE
Fix VM info and vnc calls

### DIFF
--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -196,8 +196,12 @@ VM.info = function info(req, res, next) {
         types = req.params.info.split(',');
     }
 
+    var opts = {
+        types: types
+    };
+
     req.stash.vm.info(
-        types,
+        opts,
         function (error, infoResponse) {
             clearTimeout(timeout);
 
@@ -250,10 +254,12 @@ VM.vnc = function vnc(req, res, next) {
             'Time-out reached waiting for machine_load request to return'));
     }, vmVNCTimeoutSeconds * 1000);
 
-    var types = ['vnc'];
+    var opts = {
+      types: ['vnc']
+    };
 
     req.stash.vm.info(
-        types,
+        opts,
         function (error, infoResponse) {
             clearTimeout(timeout);
 


### PR DESCRIPTION
After plumbing CNAPI VNC calls through to CloudAPI I realized that the CNAPI info and vnc calls didn't actually work because types were not being specified. The omission of types caused vmadmd to respond with an error.

This change passes the object that the task request methods expect, with the types array populated.