### PR TITLE
undo removal of ability to load VM objects through cn-agent

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1240,8 +1240,6 @@ None.
 
 ## VmLoad (GET /servers/:server_uuid/vms/:uuid)
 
-(DEPRECATED: use VMAPI instead)
-
 Query the server for the VM's details.
 
 

--- a/lib/endpoints/vms.js
+++ b/lib/endpoints/vms.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright (c) 2016, Joyent, Inc.
  */
 
 /*
@@ -81,7 +81,6 @@ VM.list = function list(req, res, next) {
 };
 
 /**
- * (DEPRECATED: use VMAPI instead)
  *
  * Query the server for the VM's details.
  *
@@ -98,20 +97,47 @@ VM.list = function list(req, res, next) {
 
 var vmLoadTimeoutSeconds = 60;
 VM.load = function load(req, res, next) {
-    var vmapi = new sdcClients.VMAPI({
-        url: req.stash.app.config.vmapi.url,
-        connectTimeout: 5000
-    });
-    vmapi.getVm({
-        uuid: req.params.uuid
-    }, function (err, vm) {
-        if (err) {
-            next(err);
-            return;
-        }
-        res.send(200, vm);
+    var responded;
+
+    if (validation.ensureParamsValid(req, res, vmValidationRules)) {
         next();
-    });
+        return;
+    }
+
+    var timeout = setTimeout(function () {
+        responded = true;
+        next(new restify.InternalError(
+            'Time-out reached waiting for machine_load request to return'));
+    }, vmLoadTimeoutSeconds * 1000);
+
+    req.stash.vm.load(
+        { req: req },
+        function (error, vm) {
+            clearTimeout(timeout);
+
+            if (responded && error) {
+                req.log.error(error.message);
+                return;
+            }
+
+            if (responded) {
+                req.log.warn('Got a reply back from an expired request');
+                return;
+            }
+
+            if (error) {
+                if (errDetails(error).restCode === 'VmNotFound') {
+                    next(new restify.ResourceNotFoundError('VM ' +
+                        req.params.uuid + ' not found'));
+                } else {
+                    next(new restify.InternalError(error.message));
+                }
+                return;
+            }
+            res.send(vm);
+            next();
+            return;
+        });
 };
 
 


### PR DESCRIPTION
The ability to load a VM from cn-agent is actually important functionality that things rely on for correct operation and should not have been removed.

This is the initial work, but tests should also be added to ensure that this doesn't get done again.
