### PR TITLE
cn-agent pause/resume + Fixed tasks history

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1089,11 +1089,12 @@ Reboot the server.
 
 ### Inputs
 
-| Param        | Type   | Description |
-| ------------ | ------ | ----------- |
-| origin       | String |             |
-| creator_uuid | String |             |
 
+| Param        | Type    | Description                                                                  |
+| ------------ | ------- | ---------------------------------------------------------------------------- |
+| drain        | Boolean | Wait for server's cn-agent to be drained before sending the reboot command   |
+| origin       | String  |                                                                              |
+| creator_uuid | String  |                                                                              |
 
 ### Responses
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ markdown2extras: tables, code-friendly
 -->
 
 <!--
-    Copyright (c) 2014, Joyent, Inc.
+    Copyright 2016, Joyent, Inc.
 -->
 
 <!-- WARNING: index.md is generated from docs/index/index.md.ejs.
@@ -1195,7 +1195,7 @@ None.
 
 | Code | Type  | Description                 |
 | ---- | ----- | --------------------------- |
-| 204  | None  | Tasks returned successfully |
+| 200  | None  | Tasks returned successfully |
 | 500  | Error | Could not process request   |
 
 
@@ -1222,7 +1222,7 @@ compute node zpool.
 | 500  | Error | Could not process request   |
 
 
-## ServerInstallAgent (GET /servers/:server_uuid/install-agent)
+## ServerInstallAgent (POST /servers/:server_uuid/install-agent)
 
 Instruct server to install given agent. Pass in image uuid of package to
 install and server will download and install package.
@@ -1239,10 +1239,10 @@ install and server will download and install package.
 
 ### Responses
 
-| Code | Type  | Description                 |
-| ---- | ----- | --------------------------- |
-| 204  | None  | Tasks returned successfully |
-| 500  | Error | Could not process request   |
+| Code | Type  | Description                      |
+| ---- | ----- | -------------------------------- |
+| 200  | None  | Successfully initiated the setup |
+| 500  | Error | Could not process request        |
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1245,6 +1245,43 @@ install and server will download and install package.
 | 500  | Error | Could not process request        |
 
 
+## ServerCnAgentPause (GET /servers/:server_uuid/cn-agent/pause)
+
+Makes cn-agent stop accepting new tasks.
+
+
+### Inputs
+
+None.
+
+
+### Responses
+
+| Code | Type  | Description                 |
+| ---- | ----- | --------------------------- |
+| 204  | None  | Request returned ok         |
+| 500  | Error | Could not process request   |
+
+
+## ServerCnAgentResume (GET /servers/:server_uuid/cn-agent/resume)
+
+Makes cn-agent accept new tasks again. Note that this is the default
+behavior and therefore it has no sense to call this method unless
+the task agent has been paused before.
+
+### Inputs
+
+None.
+
+
+### Responses
+
+| Code | Type  | Description                 |
+| ---- | ----- | --------------------------- |
+| 204  | None  | Request returned ok         |
+| 500  | Error | Could not process request   |
+
+
 
 # Virtual Machine API
 

--- a/lib/endpoints/servers.js
+++ b/lib/endpoints/servers.js
@@ -794,7 +794,6 @@ Server.del = function (req, res, next) {
 /* END JSSTYLED */
 
 Server.taskHistory = function (req, res, next) {
-    var self = this;
     var server = req.stash.server;
 
     var rules = {

--- a/lib/endpoints/servers.js
+++ b/lib/endpoints/servers.js
@@ -818,6 +818,63 @@ Server.taskHistory = function (req, res, next) {
     });
 };
 
+/* BEGIN JSSTYLED */
+/**
+ * Makes cn-agent stop accepting new tasks
+ *
+ * @name ServerPauseCnAgent
+ * @endpoint GET /servers/:server_uuid/cn-agent/pause
+ * @section Server API
+ *
+ * @response 204 No Content on success
+ * @response 500 Error Could not process request
+ */
+/* END JSSTYLED */
+Server.pauseCnAgent = function (req, res, next) {
+    var server = req.stash.server;
+    server.sendRequest({
+        method: 'post',
+        path: '/pause'
+    }, function (err) {
+        if (err) {
+            next(new restify.InternalError(err));
+            return;
+        }
+        res.send(204);
+        next();
+    });
+};
+
+/* BEGIN JSSTYLED */
+/**
+ * Makes cn-agent accept new tasks
+ *
+ * Note this is the default behavior and this end-point is useful
+ * only after a previous call to ServerPauseCnAgent
+ *
+ * @name ServerResumeCnAgent
+ * @endpoint GET /servers/:server_uuid/cn-agent/resume
+ * @section Server API
+ *
+ * @response 204 No Content on success
+ * @response 500 Error Could not process request
+ */
+/* END JSSTYLED */
+Server.resumeCnAgent = function (req, res, next) {
+    var server = req.stash.server;
+    server.sendRequest({
+        method: 'post',
+        path: '/resume'
+    }, function (err) {
+        if (err) {
+            next(new restify.InternalError(err));
+            return;
+        }
+        res.send(204);
+        next();
+    });
+};
+
 Server.eventHeartbeat = function (req, res, next) {
     var rules = {
         'server_uuid': ['isStringType']
@@ -1067,6 +1124,29 @@ function attachTo(http, app) {
             connected: ['moray']
         }),
         Server.taskHistory);
+
+    // cn-agent pause-resume
+    http.post({
+        path: '/servers/:server_uuid/cn-agent/pause',
+        name: 'ServerPauseCnAgent' },
+        ensure({
+            connectionTimeoutSeconds: 60 * 60,
+            app: app,
+            prepopulate: ['server'],
+            connected: ['moray']
+        }),
+        Server.pauseCnAgent);
+
+    http.post({
+        path: '/servers/:server_uuid/cn-agent/resume',
+        name: 'ServerResumeCnAgent' },
+        ensure({
+            connectionTimeoutSeconds: 60 * 60,
+            app: app,
+            prepopulate: ['server'],
+            connected: ['moray']
+        }),
+        Server.resumeCnAgent);
 
     http.post({
         path: '/servers/:server_uuid/events/heartbeat',

--- a/lib/endpoints/servers.js
+++ b/lib/endpoints/servers.js
@@ -1,5 +1,5 @@
-/*!
- * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+/*
+ * Copyright 2016, Joyent, Inc. All rights reserved.
  *
  * HTTP endpoints for interacting with compute nodes.
  *
@@ -788,7 +788,7 @@ Server.del = function (req, res, next) {
  * @endpoint GET /servers/:server_uuid/task-history
  * @section Server API
  *
- * @response 204 None Tasks returned successfully
+ * @response 200 Ok Tasks returned successfully
  * @response 500 Error Could not process request
  */
 /* END JSSTYLED */
@@ -806,28 +806,17 @@ Server.taskHistory = function (req, res, next) {
         return;
     }
 
-    function callback(error, msg) {
-        if (error) {
-            next(new restify.InternalError(error.message));
+    server.sendRequest({
+        method: 'get',
+        path: '/history'
+    }, function (err, history) {
+        if (err) {
+            next(new restify.InternalError(err));
             return;
         }
-        res.send(msg);
+        res.send(200, history);
         next();
-        return;
-    }
-
-    var request = {
-        task: 'show_tasks',
-        cb: function (error, task) {
-        },
-        evcb: function () {},
-        synccb: function (error, result) {
-            callback(error, result);
-        },
-        params: { uuid: self.uuid }
-    };
-
-    server.sendTaskRequest(request);
+    });
 };
 
 Server.eventHeartbeat = function (req, res, next) {
@@ -909,13 +898,13 @@ Server.ensureImage = function (req, res, next) {
  * install and server will download and install package.
  *
  * @name ServerInstallAgent
- * @endpoint GET /servers/:server_uuid/install-agent
+ * @endpoint POST /servers/:server_uuid/install-agent
  * @section Server API
  * @param {String} image_uuid UUID of image to install
  * @param {String} package_name Package name
  * @param {String} package_file Package file
  *
- * @response 204 None Tasks returned successfully
+ * @response 200 Ok Install task initiated successfully
  * @response 500 Error Could not process request
  */
 /* END JSSTYLED */

--- a/lib/endpoints/servers.js
+++ b/lib/endpoints/servers.js
@@ -521,8 +521,10 @@ Server.reboot = function (req, res, next) {
     req.stash.server.getRaw(function (error, rawserver) {
         var params = {
             origin: req.params.origin,
-            creator_uuid: req.params.creator_uuid
+            creator_uuid: req.params.creator_uuid,
+            drain: req.params.drain
         };
+
         req.stash.server.reboot(params, function (rebootError, jobUuid) {
             if (rebootError) {
                 next(new restify.InternalError(rebootError.message));

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -2251,6 +2251,87 @@ function (opts) {
     }
 };
 
+
+/**
+ * Send HTTP request to CN-Agent.
+ *
+ * For use with 'POST /tasks' end-point use 'sendTaskRequest' above
+ *
+ */
+ModelServer.prototype.sendRequest = function (opts, cb) {
+    var self = this;
+
+    assert.string(opts.path, 'opts.path');
+    assert.string(opts.method, 'opts.method');
+    assert.optionalObject(opts.params, 'opts.params');
+    assert.func(cb, 'cb');
+
+    var method = opts.method.toLowerCase();
+    var params = opts.params || {};
+    var serverAdminIp;
+    var client;
+
+    var log = self.log;
+
+    async.waterfall([
+        function getAdminIpFromSysinfo(wfcb) {
+            self.getRaw(function (err, server) {
+                if (err) {
+                    wfcb(new verror.VError(err, err));
+                   return;
+                }
+
+                if (!server) {
+                    wfcb(new verror.VError('server not found'));
+                   return;
+                }
+
+                try {
+                    serverAdminIp = firstAdminIp(server.sysinfo);
+                } catch (e) {
+                    cb(new verror.VError(e, 'parsing server ip address'));
+                    return;
+                }
+
+                log.info('sysinfo for %s before HTTP request', self.uuid);
+                wfcb();
+            });
+        },
+        function executeRequest(wfcb) {
+            var cOpts = {
+                url: 'http://' + serverAdminIp + ':' + 5309,
+                requestTimeout: 3600 * 1000,
+                connectTimeout: 3600 * 1000
+            };
+            var rOpts = { path: opts.path };
+
+            client = restify.createJsonClient(cOpts);
+
+            log.info('Excuting %s request to %s%s',
+                    method, cOpts.url, rOpts.path);
+            function reqCb(err, req, res, obj) {
+                client.close();
+
+                if (err) {
+                    wfcb(err);
+                    return;
+                }
+                wfcb(null, obj);
+            }
+
+            if (method === 'post' || method === 'put') {
+                client[method](rOpts, params, reqCb);
+            } else {
+                client[method](rOpts, reqCb);
+            }
+        }
+    ],
+    function (error, results) {
+        log.info('done executing client request');
+        cb(error, results);
+    });
+};
+
 ModelServer.prototype.zfsTask = function (task, options, callback) {
     var self = this;
 

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -525,7 +525,8 @@ ModelServer.prototype.reboot = function (params, callback) {
             server_uuid: uuid,
             target: uuid,
             origin: params.origin,
-            creator_uuid: params.creator_uuid
+            creator_uuid: params.creator_uuid,
+            drain: params.drain || false
         };
 
         self.log.info('Instantiating server-reboot workflow');

--- a/lib/workflows/server-reboot.js
+++ b/lib/workflows/server-reboot.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2016, Joyent, Inc.
  */
 
 /*
@@ -13,7 +13,7 @@
  *
  */
 
-var VERSION = '1.0.0';
+var VERSION = '1.1.0';
 
 var cnapiCommon = require('wf-shared').cnapi;
 var napiCommon = require('wf-shared').napi;
@@ -33,6 +33,88 @@ function validateParams(job, callback) {
 
     callback(null, 'All parameters OK!');
 }
+
+function pauseCnTaskHandler(job, callback) {
+    // Only with "job.params.drain"
+    if (!job.params.drain) {
+        callback(null, job);
+        return;
+    }
+    var pause = '/servers/' + job.params.server_uuid + '/cn-agent/pause';
+    var cnapiUrl = job.params.cnapi_url;
+    var cnapi = restify.createJsonClient({ url: cnapiUrl});
+
+    cnapi.post(pause, {}, function (error, req, res) {
+        if (error) {
+            job.log.info('Error trying to pause cn-agent via CNAPI:' +
+                    error.message);
+            job.log.info(error.stack.toString());
+            callback(error);
+            return;
+        }
+        callback();
+    });
+}
+
+
+function waitForCnAgentDrained(job, callback) {
+    // Only with "job.params.drain"
+    if (!job.params.drain) {
+        callback();
+        return;
+    }
+
+    var attempts = 0;
+    var errors = 0;
+
+    var timeout = 5000;  // 5 seconds
+    var limit = 180;     // 15 minutes
+
+    var hPath = '/servers/' + job.params.server_uuid + '/task-history';
+    var cnapiUrl = job.params.cnapi_url;
+    var cnapi = restify.createJsonClient({ url: cnapiUrl});
+
+    function _waitForRunningTasks() {
+        cnapi.get(hPath, function (err, req, res, history) {
+            attempts += 1;
+
+            if (err) {
+                errors += 1;
+                if (errors >= 5) {
+                    callback(err);
+                    return;
+                } else {
+                    setTimeout(_waitForRunningTasks, timeout);
+                    return;
+                }
+            }
+
+            var runningTasks = [];
+
+            if (history && history.length) {
+                runningTasks = history.filter(function (t) {
+                    return (t.status === 'active');
+                });
+            }
+
+            if (runningTasks.length) {
+                if (attempts > limit) {
+                    callback(new Error(
+                        'Waiting for cn-agent tasks to drain timed out'));
+                    return;
+                } else {
+                    setTimeout(_waitForRunningTasks, timeout);
+                    return;
+                }
+            } else {
+                callback();
+                return;
+            }
+        });
+    }
+    _waitForRunningTasks();
+}
+
 
 function sendRebootMessage(job, callback) {
     var urUrl = '/servers/' + job.params.server_uuid + '/execute';
@@ -78,7 +160,7 @@ function markServerAsRebooting(job, callback) {
 module.exports = {
     name: 'server-reboot-' + VERSION,
     version: VERSION,
-    timeout: 2*60*60,
+    timeout: 2 * 60 * 60,
     onerror: [
         {
             name: 'onerror',
@@ -93,6 +175,18 @@ module.exports = {
             timeout: 10,
             retry: 1,
             body: validateParams
+        },
+        {
+            name: 'cnapi.pause_cn_agent_task_handler',
+            timeout: 30,
+            retry: 1,
+            body: pauseCnTaskHandler
+        },
+        {
+            name: 'cnapi.wait_for_cn_agent_drained',
+            timeout: 15 * 60,
+            retry: 1,
+            body: waitForCnAgentDrained
         },
         {
             name: 'cnapi.send_reboot_message',

--- a/test/api/test-tasks.js
+++ b/test/api/test-tasks.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2016, Joyent, Inc.
  */
 
 var Logger = require('bunyan');
@@ -391,7 +391,20 @@ function testCreateTaskMultipleWaitError(test) {
     });
 }
 
+function testTaskHistory(test) {
+    test.expect(3);
 
+    function getCb(err, req, res, obj) {
+        test.ifError(err, 'no error');
+        if (!err) {
+            test.equal(res.statusCode, 200, '/task-history returns 200 OK');
+            test.ok(Array.isArray(obj), 'task history is an array of tasks');
+        }
+        test.done();
+    }
+
+    client.get(sprintf('/servers/%s/task-history', serveruuid), getCb);
+}
 
 module.exports = {
     setUp: setup,
@@ -404,7 +417,8 @@ module.exports = {
     'task expiry': testTaskExpiry,
     'create task and wait multiple times on it': testCreateTaskMultipleWait,
     'create task (with error) and wait multiple times on it':
-        testCreateTaskMultipleWaitError
+        testCreateTaskMultipleWaitError,
+    'task history': testTaskHistory
     // TODO: overlapping expiry times
     //   wait1    x------------x
     //   wait2            x------------x

--- a/test/api/test-tasks.js
+++ b/test/api/test-tasks.js
@@ -406,6 +406,34 @@ function testTaskHistory(test) {
     client.get(sprintf('/servers/%s/task-history', serveruuid), getCb);
 }
 
+function testPauseCnAgent(test) {
+    test.expect(2);
+
+    function postCb(err, req, res, obj) {
+        test.ifError(err, 'no error');
+        if (!err) {
+            test.equal(res.statusCode, 204, '/cn-agent/pause returns 204 OK');
+        }
+        test.done();
+    }
+
+    client.post(sprintf('/servers/%s/cn-agent/pause', serveruuid), {}, postCb);
+}
+
+function testResumeCnAgent(test) {
+    test.expect(2);
+
+    function postCb(err, req, res, obj) {
+        test.ifError(err, 'no error');
+        if (!err) {
+            test.equal(res.statusCode, 204, '/cn-agent/resume returns 204 OK');
+        }
+        test.done();
+    }
+
+    client.post(sprintf('/servers/%s/cn-agent/resume', serveruuid), {}, postCb);
+}
+
 module.exports = {
     setUp: setup,
     tearDown: teardown,
@@ -418,7 +446,9 @@ module.exports = {
     'create task and wait multiple times on it': testCreateTaskMultipleWait,
     'create task (with error) and wait multiple times on it':
         testCreateTaskMultipleWaitError,
-    'task history': testTaskHistory
+    'task history': testTaskHistory,
+    'pause cn-agent': testPauseCnAgent,
+    'resume cn-agent': testResumeCnAgent
     // TODO: overlapping expiry times
     //   wait1    x------------x
     //   wait2            x------------x


### PR DESCRIPTION
@orlandov this is the part of the work into reboot-plan branch which could be merged into CNAPI master in order to:

- Get the fix for `GET /servers/:server_uuid/task-history`
- Expose `POST /servers/:uuid/cn-agent/pause|resume` through CNAPI
- Wait for the cn-agents to be drained before rebooting the servers when the `drain` param is given to the reboot request.

Mind to take a quick look before I merge?