### PR TITLE
TRITON-1970 Add 'encryption_enabled' boolean to server setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1274,7 +1274,7 @@ Initiate the server setup process for a newly started server.
 | disk_width        | String | See `man disklayout` width                                   |
 | disk_cache        | String | See `man disklayout` cache                                   |
 | disk_layout       | String | See `man disklayout` type      (single, mirror, raidz1, ...) |
-| encryption_enabled| String | See See `man mkzpool -e`                                     |
+| encryption_enabled| String | See `man mkzpool -e`                                         |
 
 
 ### Responses

--- a/docs/index.md
+++ b/docs/index.md
@@ -1265,15 +1265,16 @@ Initiate the server setup process for a newly started server.
 
 ### Inputs
 
-| Param            | Type   | Description                                                  |
-| ---------------- | ------ | ------------------------------------------------------------ |
-| nics             | Object | Nic parameters to update                                     |
-| postsetup_script | String | Script to run after setup has completed                      |
-| hostname         | String | Hostname to set for the specified server                     |
-| disk_spares      | String | See `man disklayout` spares                                  |
-| disk_width       | String | See `man disklayout` width                                   |
-| disk_cache       | String | See `man disklayout` cache                                   |
-| disk_layout      | String | See `man disklayout` type      (single, mirror, raidz1, ...) |
+| Param             | Type   | Description                                                  |
+| ----------------- | ------ | ------------------------------------------------------------ |
+| nics              | Object | Nic parameters to update                                     |
+| postsetup_script  | String | Script to run after setup has completed                      |
+| hostname          | String | Hostname to set for the specified server                     |
+| disk_spares       | String | See `man disklayout` spares                                  |
+| disk_width        | String | See `man disklayout` width                                   |
+| disk_cache        | String | See `man disklayout` cache                                   |
+| disk_layout       | String | See `man disklayout` type      (single, mirror, raidz1, ...) |
+| encryption_enabled| String | See See `man mkzpool -e`                                     |
 
 
 ### Responses

--- a/lib/endpoints/servers.js
+++ b/lib/endpoints/servers.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -14,7 +14,7 @@
  *
  */
 
-var assert =  require('assert-plus');
+var assert = require('assert-plus');
 var async = require('async');
 var qs = require('qs');
 var restify = require('restify');
@@ -27,7 +27,6 @@ var Designation = require('../designation');
 var errors = require('../errors');
 var ModelPlatform = require('../models/platform');
 var ModelServer = require('../models/server');
-var ur = require('./ur');
 var validation = require('../validation/endpoints');
 
 
@@ -742,6 +741,8 @@ Server.factoryReset = function handlerServerFactoryReset(req, res, next) {
  * @param {String} disk_cache See `man disklayout` cache
  * @param {String} disk_layout See `man disklayout` type
  *      (single, mirror, raidz1, ...)
+ * @param {String} encryption_enabled Encrypt or not the server zpool. (Boolean
+ *      String type) See `man mkzpool -e` option
  * @response 200 Object Setup initated, returns object containing workflow id
  * @response 500 None Error while processing request
  */
@@ -756,7 +757,8 @@ Server.setup = function handlerServerSetup(req, res, next) {
         'disk_spares': ['optional', 'isNumberGreaterThanEqualZeroType'],
         'disk_width': ['optional', 'isNumberGreaterThanEqualZeroType'],
         'disk_cache': ['optional', 'isBooleanString'],
-        'disk_layout': ['optional', 'isStringType']
+        'disk_layout': ['optional', 'isStringType'],
+        'encryption_enabled': ['optional', 'isBooleanString']
     };
 
     if (validation.ensureParamsValid(req, res, rules, { strict: true })) {
@@ -789,6 +791,9 @@ Server.setup = function handlerServerSetup(req, res, next) {
     }
     if (typeof (req.params.disk_cache) !== 'undefined') {
         params.disk_cache = (req.params.disk_cache === 'true');
+    }
+    if (typeof (req.params.encryption_enabled) !== 'undefined') {
+        params.encryption_enabled = (req.params.encryption_enabled === 'true');
     }
     if (typeof (req.params.disk_layout) !== 'undefined') {
         var layout = req.params.disk_layout;

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -1155,6 +1155,11 @@ ModelServer.prototype.setup = function (params, callback) {
         wfParams.disk_layout = params.disk_layout;
     }
 
+
+    if (params.hasOwnProperty('encryption_enabled')) {
+        wfParams.encryption_enabled = params.encryption_enabled;
+    }
+
     vasync.pipeline({funcs: [
         function _optionallySetHostname(_, cb) {
             if (params.hasOwnProperty('hostname') && params.hostname) {

--- a/lib/workflows/server-setup.js
+++ b/lib/workflows/server-setup.js
@@ -24,7 +24,7 @@
  * - Set server setup => true
  */
 
-var VERSION = '1.0.5';
+var VERSION = '1.0.6';
 
 var cnapiCommon = require('wf-shared').cnapi;
 var napiCommon = require('wf-shared').napi;
@@ -97,9 +97,9 @@ function clearServerAgents(job, callback) {
             job.log.info('Error clearing server.agents: ' + err.message);
             job.log.info(err.stack.toString());
             callback(err);
-        } else {
-            callback();
+            return;
         }
+        callback();
     });
 }
 
@@ -121,6 +121,11 @@ function fetchSetupFiles(job, callback) {
     }
     if (job.params.hasOwnProperty('disk_width')) {
         diskCfg += 'echo "width=' + job.params.disk_width + '"; ';
+    }
+
+    if (job.params.hasOwnProperty('encryption_enabled')) {
+        diskCfg += 'echo "encryption_enabled=\'' +
+            job.params.encryption_enabled + '\'"; ';
     }
 
     var script = [
@@ -373,7 +378,7 @@ function restartUr(job, callback) {
 
     var payload = {
         script:
-            '#!/bin/bash\n'+
+            '#!/bin/bash\n' +
             'nohup /bin/bash -c ' +
                 '"(/usr/bin/sleep 5; /usr/sbin/svcadm restart ur) &"'
     };
@@ -395,11 +400,11 @@ function restartUr(job, callback) {
 module.exports = {
     name: 'server-setup-' + VERSION,
     version: VERSION,
-    timeout: 2*60*60,
+    timeout: 2 * 60 * 60,
     onerror: [
         {
             name: 'onerror',
-            body: function (job, cb) {
+            body: function (_job, cb) {
                 cb(new Error('Error executing job'));
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cnapi",
   "description": "Triton Compute Node API",
-  "version": "1.24.5",
+  "version": "1.24.6",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
The `encryption_enabled` parameter is needed by `scripts/joysetup.sh` in order to encrypt the server's zpool during setup.

See the `sdc-headnode.git` repo's `zfs-crypto` branch for the details: https://github.com/joyent/sdc-headnode/compare/zfs-crypto.