### PR TITLE
TRITON-2010 Triton components should be aware of CNs encryption (EDAR)

### DIFF
--- a/sapi_manifests/cnapi/template
+++ b/sapi_manifests/cnapi/template
@@ -79,6 +79,7 @@
 			        "hard-filter-invalid-servers",
 			        "hard-filter-force-failure",
 			        "hard-filter-virtual-servers",
+			        "hard-filter-zpool-encryption",
 			        "hard-filter-volumes-from",
 			        "hard-filter-reserved",
 			        "hard-filter-min-free-disk",


### PR DESCRIPTION
Missing template change to apply the new filter by default.