### PR TITLE
TRITON-1969 boot_modules constraints for booter support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -486,6 +486,26 @@ To completely overwrite values, use PUT instead of POST:
         -d '{ "kernel_args": { "alpha": "able" } }'
 
 
+It's also possible to set `boot_modules` either for a single compute node or
+by default for any compute node. `boot_modules` is a collection of module
+objects. Each member of this collection is expected to have the following
+structure:
+
+      {
+          "path": "boot module path to be used by booter",
+          "type": "Content type. Right now only base64 is supported",
+          "content": "File contents, if necessary encoded as specified"
+      }
+
+While it's possible that new content types could be added in the future, right
+now file contents are expected to be base64 encoded and max content length is
+of 4KB. When no value for `content` is specified, it's assumed to be the
+default.
+
+    -bash-4.1# sdc-cnapi /boot/ \
+        -X PUT \
+        -d '{ "boot_modules": [ { "path": "etc/ppt_aliases", "content": "cHB0ICIvcGNpQDAsMC9wY2k4MDg2LDE1MUAxL2Rpc3BsYXlAMCIK" } ] }'
+
 # Setting up a new Server
 
 Setting when a new server comes online its `status` should be be visible as

--- a/docs/README.md
+++ b/docs/README.md
@@ -499,10 +499,10 @@ structure:
 
 While it's possible that new content types could be added in the future, right
 now file contents are expected to be base64 encoded and max content length is
-of 4KB. When no value for `content` is specified, it's assumed to be the
+of 4KB. When no value for `content` if specified, it's assumed to be the
 default.
 
-    -bash-4.1# sdc-cnapi /boot/ \
+    -bash-4.1# sdc-cnapi /boot/21306a50-9dad-11e3-9404-53f0c3de6cb8 \
         -X PUT \
         -d '{ "boot_modules": [ { "path": "etc/ppt_aliases", "content": "cHB0ICIvcGNpQDAsMC9wY2k4MDg2LDE1MUAxL2Rpc3BsYXlAMCIK" } ] }'
 

--- a/lib/endpoints/boot_params.js
+++ b/lib/endpoints/boot_params.js
@@ -25,9 +25,8 @@ var ModelPlatform = require('../models/platform');
  *      "content": "File contents, if necessary encoded as specified by type"
  * }
  *
- * In the future, support for new content types or additionaly members for
- * the boot_module objects could be provided, being the defaults the originally
- * supported values.
+ * In the future, support for new content types or additional members for
+ * the boot_module objects could be provided, defaulting to base64.
  */
 function validateBootModules(boot_modules) {
     var errs = [];
@@ -47,16 +46,16 @@ function validateBootModules(boot_modules) {
                 'Unsupported type %s for module %s', bm.type, bm.path));
             continue;
         }
+        if (Buffer.byteLength(bm.content, 'base64') > 4 * 1024) {
+            errs.push(util.format(
+                'Module %s exceeds the maximum allowed size of 4KB',
+                bm.path));
+            continue;
+        }
         if (Buffer.from(bm.content, 'base64').toString('base64') !==
             bm.content) {
             errs.push(util.format(
                 'Contents for module %s must be base64 encoded', bm.path));
-            continue;
-        }
-        if (Buffer.byteLength(bm.content, 'base64') > 4 * 1024) {
-            errs.push(util.format(
-                'Module %s exceeds the maximum allowed size of 4KBs',
-                bm.path));
             continue;
         }
     }
@@ -116,7 +115,24 @@ BootParams.getDefault = function handlerBootParamsGetDefault(req, res, next) {
  *
  * @param {String} platform The platform image to use on next boot
  * @param {Object} kernel_args Key value pairs to be sent to server on boot
- * @param {Array} boot_modules List of boot module objects
+ * @param {Array} boot_modules List of boot module objects.
+ *      Each member of this collection will be an object with the
+ *      following structure:
+ *      {
+ *          "path": "boot module path to be used by booter",
+ *          "type": "Content type. Right now only base64 is supported",
+ *          "content": "File contents, if necessary encoded as specified"
+ *      }
+ *      File contents are expected to be base64 encoded and max content
+ *      length is of 4KB.
+ *      [{
+ *          "path": ...,
+ *          "content": ...,
+ *          "type": "base64 (default)"
+ *       }, {
+ *          "path": "...",
+ *          "content": "..."
+ *       }, ...]
  * @param {Object} kernel_flags Kernel flags to be sent to server on boot
  * @param {Object} serial Serial device to use (i.e. "ttyb")
  * @param {Object} default_console Default console type (i.e. "serial")
@@ -139,11 +155,22 @@ BootParams.setDefault = function handlerBootParamsSetDefault(req, res, next) {
     var params = {
         boot_platform: req.params.platform,
         boot_params: req.params.kernel_args,
-        boot_modules: req.params.boot_modules,
 
         default_console: req.params.default_console,
         serial: req.params.serial
     };
+
+
+    if (req.params.boot_modules) {
+        var bootmErr = validateBootModules(req.params.boot_modules);
+        if (bootmErr) {
+            res.send(bootmErr);
+            next();
+            return;
+        }
+    }
+
+    params.boot_modules = req.params.boot_modules || [];
 
     if (req.params['platform']) {
         ModelPlatform.list({}, function (error, platforms) {
@@ -193,7 +220,24 @@ BootParams.setDefault = function handlerBootParamsSetDefault(req, res, next) {
  * @section Boot Parameters API
  *
  * @param {Object} kernel_args Boot parms to update
- * @param {Array} boot_modules List of boot module objects
+ * @param {Array} boot_modules List of boot module objects.
+ *      Each member of this collection will be an object with the
+ *      following structure:
+ *      {
+ *          "path": "boot module path to be used by booter",
+ *          "type": "Content type. Right now only base64 is supported",
+ *          "content": "File contents, if necessary encoded as specified"
+ *      }
+ *      File contents are expected to be base64 encoded and max content
+ *      length is of 4KB.
+ *      [{
+ *          "path": ...,
+ *          "content": ...,
+ *          "type": "base64 (default)"
+ *       }, {
+ *          "path": "...",
+ *          "content": "..."
+ *       }, ...]
  * @param {Object} kernel_flags Kernel flags to update
  * @param {String} platform Set platform as the bootable platform
  *
@@ -227,7 +271,16 @@ function handlerBootParamsUpdateDefault(req, res, next) {
 
     params.default_console = req.params.default_console;
     params.serial = req.params.serial;
-    params.boot_modules = req.params.boot_modules;
+
+    if (req.params.boot_modules) {
+        var bootmErr = validateBootModules(req.params.boot_modules);
+        if (bootmErr) {
+            res.send(bootmErr);
+            next();
+            return;
+        }
+    }
+    params.boot_modules = req.params.boot_modules || [];
 
     if (req.params['platform']) {
         ModelPlatform.list({}, function (error, platforms) {
@@ -328,7 +381,7 @@ BootParams.getByUuid = function handlerBootParamsGetByUuid(req, res, next) {
  *          "content": "File contents, if necessary encoded as specified"
  *      }
  *      File contents are expected to be base64 encoded and max content
- *      length is of 4kbs.
+ *      length is of 4KB.
  *      [{
  *          "path": ...,
  *          "content": ...,
@@ -448,7 +501,7 @@ BootParams.setByUuid = function handlerBootParamsSetByUuid(req, res, next) {
  *          "content": "File contents, if necessary encoded as specified"
  *      }
  *      File contents are expected to be base64 encoded and max content
- *      length is of 4kbs.
+ *      length is of 4KB.
  *      [{
  *          "path": ...,
  *          "content": ...,

--- a/lib/endpoints/boot_params.js
+++ b/lib/endpoints/boot_params.js
@@ -5,8 +5,9 @@
  */
 
 /*
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
+var util = require('util');
 
 var restify = require('restify');
 
@@ -14,7 +15,60 @@ var ModelServer = require('../models/server');
 var common = require('../common');
 var validation = require('../validation/endpoints');
 var ModelPlatform = require('../models/platform');
-var dns = require('dns');
+
+/*
+ * Expected boot modules format is as follows:
+ *
+ * {
+ *      "path": "boot module path to be used by booter",
+ *      "type": "Content type. Right now only base64 is supported",
+ *      "content": "File contents, if necessary encoded as specified by type"
+ * }
+ *
+ * In the future, support for new content types or additionaly members for
+ * the boot_module objects could be provided, being the defaults the originally
+ * supported values.
+ */
+function validateBootModules(boot_modules) {
+    var errs = [];
+    var i;
+    for (i = 0; i < boot_modules.length; i += 1) {
+        var bm = boot_modules[i];
+        if (!bm.path || !bm.content) {
+            errs.push(util.format(
+                'Unexpected format for boot_module: %j', bm));
+            continue;
+        }
+
+        bm.type = bm.type || 'base64';
+
+        if (bm.type !== 'base64') {
+            errs.push(util.format(
+                'Unsupported type %s for module %s', bm.type, bm.path));
+            continue;
+        }
+        if (Buffer.from(bm.content, 'base64').toString('base64') !==
+            bm.content) {
+            errs.push(util.format(
+                'Contents for module %s must be base64 encoded', bm.path));
+            continue;
+        }
+        if (Buffer.byteLength(bm.content, 'base64') > 4 * 1024) {
+            errs.push(util.format(
+                'Module %s exceeds the maximum allowed size of 4KBs',
+                bm.path));
+            continue;
+        }
+    }
+
+    if (errs.length) {
+        var err = new restify.InvalidArgumentError(
+            'Values provided for boot_modules contain errors: '
+            + errs.join(',\n'));
+        return err;
+    }
+    return null;
+}
 
 /**
  * Boot parameters are passed to compute nodes on boot. They enable one to pass
@@ -265,7 +319,24 @@ BootParams.getByUuid = function handlerBootParamsGetByUuid(req, res, next) {
  * @section Boot Parameters API
  *
  * @param {Object} kernel_args Boot parms to update
- * @param {Array} boot_modules List of boot module objects
+ * @param {Array} boot_modules List of boot module objects.
+ *      Each member of this collection will be an object with the
+ *      following structure:
+ *      {
+ *          "path": "boot module path to be used by booter",
+ *          "type": "Content type. Right now only base64 is supported",
+ *          "content": "File contents, if necessary encoded as specified"
+ *      }
+ *      File contents are expected to be base64 encoded and max content
+ *      length is of 4kbs.
+ *      [{
+ *          "path": ...,
+ *          "content": ...,
+ *          "type": "base64 (default)"
+ *       }, {
+ *          "path": "...",
+ *          "content": "..."
+ *       }, ...]
  * @param {Object} kernel_values Kernel flags to update
  * @param {String} platform Set platform as the bootable platform
  * @param {Object} serial Serial device to use (i.e. "ttyb")
@@ -304,11 +375,21 @@ BootParams.setByUuid = function handlerBootParamsSetByUuid(req, res, next) {
     }
 
     values.boot_params = req.params.kernel_args;
-    values.boot_modules = req.params.boot_modules || [];
 
     values.default_console = req.params.default_console;
     values.kernel_flags = req.params.kernel_flags;
     values.serial = req.params.serial;
+
+    if (req.params.boot_modules) {
+        var bootmErr = validateBootModules(req.params.boot_modules);
+        if (bootmErr) {
+            res.send(bootmErr);
+            next();
+            return;
+        }
+    }
+
+    values.boot_modules = req.params.boot_modules || [];
 
     ModelPlatform.list({}, function (error, platforms) {
         if (error) {
@@ -358,7 +439,24 @@ BootParams.setByUuid = function handlerBootParamsSetByUuid(req, res, next) {
  *
  * @param {Object} kernel_args Boot parms to update
  * @param {Object} kernel_flags Hash containing flag key/value pairs
- * @param {Array} boot_modules List of boot module objects
+ * @param {Array} boot_modules List of boot module objects.
+ *      Each member of this collection will be an object with the
+ *      following structure:
+ *      {
+ *          "path": "boot module path to be used by booter",
+ *          "type": "Content type. Right now only base64 is supported",
+ *          "content": "File contents, if necessary encoded as specified"
+ *      }
+ *      File contents are expected to be base64 encoded and max content
+ *      length is of 4kbs.
+ *      [{
+ *          "path": ...,
+ *          "content": ...,
+ *          "type": "base64 (default)"
+ *       }, {
+ *          "path": "...",
+ *          "content": "..."
+ *       }, ...]
  * @param {String} platform Set platform as the bootable platform
  *
  * @example POST /boot/:server_uuid -d '{ "platform": "1234Z" }'
@@ -399,6 +497,16 @@ function handlerBootParamsUpdateByUuid(req, res, next) {
 
     params.default_console = req.params.default_console;
     params.serial = req.params.serial;
+
+    if (req.params.boot_modules) {
+        var bootmErr = validateBootModules(req.params.boot_modules);
+        if (bootmErr) {
+            res.send(bootmErr);
+            next();
+            return;
+        }
+    }
+
     params.boot_modules = req.params.boot_modules;
 
     if (req.params['platform']) {

--- a/lib/endpoints/boot_params.js
+++ b/lib/endpoints/boot_params.js
@@ -33,12 +33,6 @@ function validateBootModules(boot_modules) {
     var i;
     for (i = 0; i < boot_modules.length; i += 1) {
         var bm = boot_modules[i];
-        if (!bm.path || !bm.content) {
-            errs.push(util.format(
-                'Unexpected format for boot_module: %j', bm));
-            continue;
-        }
-
         bm.type = bm.type || 'base64';
 
         if (bm.type !== 'base64') {
@@ -46,6 +40,13 @@ function validateBootModules(boot_modules) {
                 'Unsupported type %s for module %s', bm.type, bm.path));
             continue;
         }
+
+        if (!bm.path || !bm.content) {
+            errs.push(util.format(
+                'Unexpected format for boot_module: %j', bm));
+            continue;
+        }
+
         if (Buffer.byteLength(bm.content, 'base64') > 4 * 1024) {
             errs.push(util.format(
                 'Module %s exceeds the maximum allowed size of 4KB',

--- a/test/model/test-model-server.js
+++ b/test/model/test-model-server.js
@@ -5,14 +5,11 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var async = require('async');
-var vasync = require('vasync');
-var util = require('util');
 
-var common = require('../../lib/common');
 var mock = require('../lib/mock');
 var nodeunit = require('nodeunit');
 var sprintf = require('sprintf').sprintf;
@@ -65,7 +62,7 @@ function testListServersAll(test) {
 
         ModelServer.list(options, function (listError, servers) {
             test.equal(listError, null, 'should not encounter an error');
-            var expected =  [
+            var expected = [
                 {
                     last_heartbeat: null,
                     uuid: '372bdb58-f8dd-11e1-8038-0b6dbddc5e58',
@@ -94,7 +91,6 @@ function testListServersAll(test) {
                 'moray history should match');
             test.done();
         });
-
     });
 }
 
@@ -129,7 +125,7 @@ function testListServersByUuids(test) {
         ModelServer.list(options, function (listError, servers) {
             test.equal(listError, null, 'should not encounter an error');
 
-            var expected =  [
+            var expected = [
                 {
                     last_heartbeat: null,
                     uuid: '372bdb58-f8dd-11e1-8038-0b6dbddc5e58',
@@ -151,8 +147,7 @@ function testListServersByUuids(test) {
                expected,
                'Server results should match');
 
-            var filter
-                = expSearchResults
+            var filter = expSearchResults
                     .sort(function (a, b) {
                         return a.uuid > b.uuid;
                     })
@@ -210,7 +205,7 @@ function testListServersSetup(test) {
         ModelServer.list(options, function (listError, servers) {
             test.equal(listError, null, 'should not encounter an error');
 
-            var expected =  [
+            var expected = [
                 {
                     last_heartbeat: null,
                     uuid: '372bdb58-f8dd-11e1-8038-0b6dbddc5e58',
@@ -680,7 +675,12 @@ function testUpdateBootParameters(test) {
                 {
                     kernel_flags: kernelArgs,
                     boot_params: update,
-                    boot_modules: [ {}, {} ],
+                    boot_modules: [ {
+                        path: 'etc/ppt_aliases',
+                        content: Buffer.from(
+                            'ppt "/pci@0,0/pci8086,151@1/display@0"\n',
+                            'ascii').toString('base64')
+                    }],
                     boot_platform: 'newer'
                 },
                 function (modifyError) {
@@ -710,7 +710,12 @@ function testUpdateBootParameters(test) {
 
                                 setup: true,
                                 boot_platform: 'newer',
-                                boot_modules: [ {}, {} ],
+                                boot_modules: [ {
+                                    path: 'etc/ppt_aliases',
+                                    content: Buffer.from(
+                                    'ppt "/pci@0,0/pci8086,151@1/display@0"\n',
+                                    'ascii').toString('base64')
+                                }],
                                 hostname: 'testbox',
                                 sysinfo: { 'setup': true },
                                 default_console: 'serial',
@@ -728,7 +733,12 @@ function testUpdateBootParameters(test) {
                 boot_params: updatedBootParams,
                 setup: true,
                 boot_platform: 'newer',
-                boot_modules: [ {}, {} ],
+                boot_modules: [ {
+                    path: 'etc/ppt_aliases',
+                    content: Buffer.from(
+                        'ppt "/pci@0,0/pci8086,151@1/display@0"\n',
+                        'ascii').toString('base64')
+                }],
                 hostname: 'testbox',
                 sysinfo: { 'setup': true },
                 default_console: 'serial',
@@ -756,7 +766,12 @@ function testUpdateBootParameters(test) {
                         },
                         kernel_flags: updatedKernelArgs,
                         default_console: 'serial',
-                        boot_modules: [ {}, {} ],
+                        boot_modules: [ {
+                            path: 'etc/ppt_aliases',
+                            content: Buffer.from(
+                                'ppt "/pci@0,0/pci8086,151@1/display@0"\n',
+                                'ascii').toString('base64')
+                        }],
                         serial: 'ttyb'
                     });
 


### PR DESCRIPTION
Current `boot_modules` support by CNAPI is too widely open in order to reliably implement a procedure from booter which could result into boot modules being written to disk for every CN using them and properly provided to the boot requests made to dhcpd zone, even when CNAPI is down (i.e. cached).

Constrains added: Each boot module will be specified as `{'file-name': 'file-contents'}` where `file-contents` is base64 encoded and not bigger than 4KBs (size is arbitrary and could be modified in the future or made it configurable through SAPI).