### PR TITLE
TRITON-1969 Validate boot_modules paths do not contain either "." or ".."

### DIFF
--- a/lib/endpoints/boot_params.js
+++ b/lib/endpoints/boot_params.js
@@ -7,14 +7,15 @@
 /*
  * Copyright 2020 Joyent, Inc.
  */
-var util = require('util');
+const path = require('path');
+const util = require('util');
 
-var restify = require('restify');
+const restify = require('restify');
 
-var ModelServer = require('../models/server');
-var common = require('../common');
-var validation = require('../validation/endpoints');
-var ModelPlatform = require('../models/platform');
+const ModelServer = require('../models/server');
+const common = require('../common');
+const validation = require('../validation/endpoints');
+const ModelPlatform = require('../models/platform');
 
 /*
  * Expected boot modules format is as follows:
@@ -37,7 +38,7 @@ function validateBootModules(boot_modules) {
 
         if (bm.type !== 'base64') {
             errs.push(util.format(
-                'Unsupported type %s for module %s', bm.type, bm.path));
+                'Unsupported type %s for module \'%s\'', bm.type, bm.path));
             continue;
         }
 
@@ -47,16 +48,24 @@ function validateBootModules(boot_modules) {
             continue;
         }
 
+        if (/[.]+/.test(path.dirname(bm.path))) {
+            errs.push(util.format(
+                'Invalid path for boot_module: \'%s\' ' +
+                '(path cannot contain \'.\' or \'..\')', bm.path));
+            continue;
+        }
+
         if (Buffer.byteLength(bm.content, 'base64') > 4 * 1024) {
             errs.push(util.format(
-                'Module %s exceeds the maximum allowed size of 4KB',
+                'Module \'%s\' exceeds the maximum allowed size of 4KB',
                 bm.path));
             continue;
         }
+
         if (Buffer.from(bm.content, 'base64').toString('base64') !==
             bm.content) {
             errs.push(util.format(
-                'Contents for module %s must be base64 encoded', bm.path));
+                'Contents for module \'%s\' must be base64 encoded', bm.path));
             continue;
         }
     }

--- a/lib/endpoints/boot_params.js
+++ b/lib/endpoints/boot_params.js
@@ -7,8 +7,6 @@
 /*
  * Copyright 2020 Joyent, Inc.
  */
-const path = require('path');
-const util = require('util');
 
 const restify = require('restify');
 
@@ -17,67 +15,6 @@ const common = require('../common');
 const validation = require('../validation/endpoints');
 const ModelPlatform = require('../models/platform');
 
-/*
- * Expected boot modules format is as follows:
- *
- * {
- *      "path": "boot module path to be used by booter",
- *      "type": "Content type. Right now only base64 is supported",
- *      "content": "File contents, if necessary encoded as specified by type"
- * }
- *
- * In the future, support for new content types or additional members for
- * the boot_module objects could be provided, defaulting to base64.
- */
-function validateBootModules(boot_modules) {
-    var errs = [];
-    var i;
-    for (i = 0; i < boot_modules.length; i += 1) {
-        var bm = boot_modules[i];
-        bm.type = bm.type || 'base64';
-
-        if (bm.type !== 'base64') {
-            errs.push(util.format(
-                'Unsupported type %s for module \'%s\'', bm.type, bm.path));
-            continue;
-        }
-
-        if (!bm.path || !bm.content) {
-            errs.push(util.format(
-                'Unexpected format for boot_module: %j', bm));
-            continue;
-        }
-
-        if (/[.]+/.test(path.dirname(bm.path))) {
-            errs.push(util.format(
-                'Invalid path for boot_module: \'%s\' ' +
-                '(path cannot contain \'.\' or \'..\')', bm.path));
-            continue;
-        }
-
-        if (Buffer.byteLength(bm.content, 'base64') > 4 * 1024) {
-            errs.push(util.format(
-                'Module \'%s\' exceeds the maximum allowed size of 4KB',
-                bm.path));
-            continue;
-        }
-
-        if (Buffer.from(bm.content, 'base64').toString('base64') !==
-            bm.content) {
-            errs.push(util.format(
-                'Contents for module \'%s\' must be base64 encoded', bm.path));
-            continue;
-        }
-    }
-
-    if (errs.length) {
-        var err = new restify.InvalidArgumentError(
-            'Values provided for boot_modules contain errors: '
-            + errs.join(',\n'));
-        return err;
-    }
-    return null;
-}
 
 /**
  * Boot parameters are passed to compute nodes on boot. They enable one to pass
@@ -172,7 +109,7 @@ BootParams.setDefault = function handlerBootParamsSetDefault(req, res, next) {
 
 
     if (req.params.boot_modules) {
-        var bootmErr = validateBootModules(req.params.boot_modules);
+        var bootmErr = validation.validateBootModules(req.params.boot_modules);
         if (bootmErr) {
             res.send(bootmErr);
             next();
@@ -283,7 +220,7 @@ function handlerBootParamsUpdateDefault(req, res, next) {
     params.serial = req.params.serial;
 
     if (req.params.boot_modules) {
-        var bootmErr = validateBootModules(req.params.boot_modules);
+        var bootmErr = validation.validateBootModules(req.params.boot_modules);
         if (bootmErr) {
             res.send(bootmErr);
             next();
@@ -444,7 +381,7 @@ BootParams.setByUuid = function handlerBootParamsSetByUuid(req, res, next) {
     values.serial = req.params.serial;
 
     if (req.params.boot_modules) {
-        var bootmErr = validateBootModules(req.params.boot_modules);
+        var bootmErr = validation.validateBootModules(req.params.boot_modules);
         if (bootmErr) {
             res.send(bootmErr);
             next();
@@ -562,7 +499,7 @@ function handlerBootParamsUpdateByUuid(req, res, next) {
     params.serial = req.params.serial;
 
     if (req.params.boot_modules) {
-        var bootmErr = validateBootModules(req.params.boot_modules);
+        var bootmErr = validation.validateBootModules(req.params.boot_modules);
         if (bootmErr) {
             res.send(bootmErr);
             next();

--- a/lib/validation/endpoints.js
+++ b/lib/validation/endpoints.js
@@ -1,14 +1,17 @@
 /*
- * Copyright (c) 2019, Joyent, Inc. All rights reserved.
+ * Copyright 2020, Joyent, Inc. All rights reserved.
  *
  * HTTP endpoints validation routines.
  *
  */
 
-var sprintf = require('sprintf').sprintf;
-var VError = require('verror');
-var restify = require('restify');
-var restify_validator = require('restify-validator');
+const path = require('path');
+const util = require('util');
+
+const restify = require('restify');
+const restify_validator = require('restify-validator');
+const sprintf = require('sprintf').sprintf;
+const VError = require('verror');
 
 // Restcode = InvalidParameters
 
@@ -69,7 +72,7 @@ function ensureParamsValid(req, res, paramRules, opts) {
             rule = paramRules[paramName][ruleIdx];
             var ruleName;
 
-            if (global.toString.call(rule) == '[object String]') {
+            if (global.toString.call(rule) === '[object String]') {
                 ruleName = rule;
                 rule = [ruleName];
             } else if (Array.isArray(rule)) {
@@ -93,7 +96,6 @@ function ensureParamsValid(req, res, paramRules, opts) {
 
                     if (!params.hasOwnProperty(paramName) ||
                         params[paramName] === undefined) {
-
                         skip = true;
                         params[paramName] = rule[1];
                         break;
@@ -240,7 +242,7 @@ function ensureParamsValid(req, res, paramRules, opts) {
 function updateLimitedToInternalMetadata(req, res, name) {
     if (req.params.hasOwnProperty('update')) {
         var keys = Object.keys(req.params.update);
-        if (keys.length != 1 || keys[0] !== 'set_internal_metadata') {
+        if (keys.length !== 1 || keys[0] !== 'set_internal_metadata') {
             res.send(
                 500,
                 new restify.InvalidArgumentError(
@@ -252,8 +254,71 @@ function updateLimitedToInternalMetadata(req, res, name) {
     return null;
 }
 
+/*
+ * Expected boot modules format is as follows:
+ *
+ * {
+ *      "path": "boot module path to be used by booter",
+ *      "type": "Content type. Right now only base64 is supported",
+ *      "content": "File contents, if necessary encoded as specified by type"
+ * }
+ *
+ * In the future, support for new content types or additional members for
+ * the boot_module objects could be provided, defaulting to base64.
+ */
+function validateBootModules(boot_modules) {
+    var errs = [];
+    var i;
+    for (i = 0; i < boot_modules.length; i += 1) {
+        var bm = boot_modules[i];
+        bm.type = bm.type || 'base64';
+
+        if (bm.type !== 'base64') {
+            errs.push(util.format(
+                'Unsupported type %s for module \'%s\'', bm.type, bm.path));
+            continue;
+        }
+
+        if (!bm.path || !bm.content) {
+            errs.push(util.format(
+                'Unexpected format for boot_module: %j', bm));
+            continue;
+        }
+
+        if (path.normalize(bm.path) !== bm.path) {
+            errs.push(util.format(
+                'Invalid path for boot_module: \'%s\' ' +
+                '(path cannot contain \'.\' or \'..\')', bm.path));
+            continue;
+        }
+
+        if (Buffer.byteLength(bm.content, 'base64') > 4 * 1024) {
+            errs.push(util.format(
+                'Module \'%s\' exceeds the maximum allowed size of 4KB',
+                bm.path));
+            continue;
+        }
+
+        if (Buffer.from(bm.content, 'base64').toString('base64') !==
+            bm.content) {
+            errs.push(util.format(
+                'Contents for module \'%s\' must be base64 encoded', bm.path));
+            continue;
+        }
+    }
+
+    if (errs.length) {
+        var err = new restify.InvalidArgumentError(
+            'Values provided for boot_modules contain errors: '
+            + errs.join(',\n'));
+        return err;
+    }
+    return null;
+}
+
 exports.ensureParamsValid = ensureParamsValid;
 exports.formatValidationErrors = formatValidationErrors;
 exports.assert = {
     updateLimitedToInternalMetadata: updateLimitedToInternalMetadata
 };
+exports.validateBootModules = validateBootModules;

--- a/test/test-servers.js
+++ b/test/test-servers.js
@@ -705,6 +705,18 @@ function testServerSysinfo(t) {
                 t.ok(!err, 'expected no error with correct boot modules');
                 next(err);
             });
+        }, function _bootModulesOkFancyPath(next) {
+            client.put('/boot/' + uuid, {
+                boot_modules: [ {
+                    path: 'etc/ppt..aliases/super...fancy.name',
+                    content: Buffer.from(
+                        'ppt "/pci@0,0/pci8086,151@1/display@0"\n',
+                        'ascii').toString('base64')
+                }]
+            }, function _onPut(err, req, res) {
+                t.ok(!err, 'expected no error with correct boot modules');
+                next(err);
+            });
         }
     ], function (err) {
         t.ok(!err, 'expected no errors when testing /sysinfo endpoint');
@@ -895,7 +907,7 @@ function validateServer(t, server, options) {
 
         var vmUuids = Object.keys(vms);
 
-        for (i = 0; i != vmUuids.length; i++) {
+        for (i = 0; i !== vmUuids.length; i++) {
             var vmUuid = vmUuids[i];
             var vm = vms[vmUuid];
 

--- a/test/test-servers.js
+++ b/test/test-servers.js
@@ -664,7 +664,7 @@ function testServerSysinfo(t) {
             }, function _onPut(err, req, res) {
                 t.ok(err, 'expected encoding error');
                 t.notEqual(err.message.indexOf('base64 encoded'),
-                    -1, 'Unexpected format');
+                    -1, 'Unexpected encoding');
                 next();
             });
         }, function _bootModulesInvalidSize(next) {
@@ -677,7 +677,20 @@ function testServerSysinfo(t) {
             }, function _onPut(err, req, res) {
                 t.ok(err, 'expected size error');
                 t.notEqual(err.message.indexOf('maximum allowed size'),
-                    -1, 'Unexpected format');
+                    -1, 'Invalid size');
+                next();
+            });
+        }, function _bootModulesInvalidPath(next) {
+            client.put('/boot/' + uuid, {
+                boot_modules: [ {
+                    path: './etc/ppt_aliases',
+                    content:
+                        new Buffer(4 * 1024).toString('base64')
+                }]
+            }, function _onPut(err, req, res) {
+                t.ok(err, 'expected path error');
+                t.notEqual(err.message.indexOf('Invalid path'),
+                    -1, 'Invalid path');
                 next();
             });
         }, function _bootModulesOk(next) {


### PR DESCRIPTION
Make sure that we don't allow any characters that `path.resolve` could _transform_ into our boot module file being saved outside bootfsdir when booter writes module files to cache.