### PR TITLE
TRITON-1643 CNAPI allows allocation to a server that does not have a last_heartbeat set

### DIFF
--- a/lib/heartbeat_reconciler.js
+++ b/lib/heartbeat_reconciler.js
@@ -4,7 +4,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -35,9 +35,18 @@ function HeartbeatReconciler(opts) {
     assert.object(opts.moray, 'opts.moray');
 
     self.app = opts.app;
-    self.log = opts.log;
+    self.log = opts.log.child({component: 'heartbeat_reconciler'});
     self.metricsManager = opts.metricsManager;
     self.moray = opts.moray;
+
+    self._setupMetricCounters();
+    self._loadLastStatus();
+}
+
+
+HeartbeatReconciler.prototype._setupMetricCounters =
+function _setupMetricCounters() {
+    var self = this;
 
     self.newHeartbeatersCounter = self.metricsManager.collector.counter({
         name: 'reconciler_new_heartbeaters_total',
@@ -97,7 +106,95 @@ function HeartbeatReconciler(opts) {
         help: 'Total number of failures trying to put cnapi_status objects'
     });
     self.statusPutFailuresCounter.add(0);
-}
+};
+
+// On cnapi startup, load the existing cnapi_status entries, which will be
+// used as the basis for determing when a server was last seen as running.
+HeartbeatReconciler.prototype._loadLastStatus = function _loadLastStatus() {
+    var self = this;
+
+    var cnapiStatusBucket = buckets.status.name;
+    var log = self.log;
+    var moray = self.moray;
+    var observedHeartbeats = self.app.observedHeartbeats;
+
+    var count = 0;
+    var filter = '(server_uuid=*)';
+    var findOpts = {};
+
+    var req = moray.findObjects(
+        cnapiStatusBucket,
+        filter,
+        findOpts);
+
+    req.on('error', _onError);
+    req.on('record', _onRecord);
+    req.on('end', _onEnd);
+
+    function _onError(error) {
+        log.error(error, 'error retriving cnapi server status');
+    }
+
+    function _onRecord(record) {
+        count += 1;
+        var entry = record.value;
+        var server_uuid = entry.server_uuid;
+        // Only add the status entry if a new one has not already been seen.
+        if (!observedHeartbeats.hasOwnProperty(server_uuid)) {
+            observedHeartbeats[server_uuid] = entry;
+            log.trace({entry: entry}, 'Added cnapi_status stored entry');
+        }
+    }
+
+    function _onEnd() {
+        log.info('Loaded %d observedHeartbeats from cnapi_status', count);
+        self._loadMissingRunningServers();
+    }
+};
+
+// On cnapi startup (and after _loadLastStatus has run), load the list of
+// running servers and ensure they have a observedHeartbeats entry - this will
+// ensure that if no ping from this server comes in, it will eventually be
+// marked with status 'unknown'.
+HeartbeatReconciler.prototype._loadMissingRunningServers =
+function _loadMissingRunningServers() {
+    var self = this;
+
+    var count = 0;
+    var log = self.log;
+    var observedHeartbeats = self.app.observedHeartbeats;
+
+    ModelServer.list({raw: true}, function (error, servers) {
+        if (error) {
+            log.error(error, 'error retriving cnapi server list');
+            return;
+        }
+
+        servers.forEach(function _checkEachServer(server) {
+            if (server.status !== 'running') {
+                return;
+            }
+
+            var entry;
+            var server_uuid = server.uuid;
+            if (!observedHeartbeats.hasOwnProperty(server_uuid)) {
+                count += 1;
+                entry = {
+                    cnapi_instance: self.app.cnapi_instance,
+                    last_heartbeat: new Date(0).toISOString(), // 1970-01-01
+                    server_uuid: server_uuid
+                };
+                observedHeartbeats[server_uuid] = entry;
+                log.debug({entry: entry},
+                    'Created observedHeartbeat for running server');
+            }
+        });
+
+        log.info({numServers: servers.length},
+            'Created %d missing observedHeartbeats for running servers',
+            count);
+    });
+};
 
 HeartbeatReconciler.prototype._serverUpdate =
 function heartbeatServerUpdate(serverUuid, opts, callback) {

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -183,11 +183,17 @@ ModelServer.init = function (app) {
 
 /**
  * Return a list of servers matching given criteria.
+ *
+ * @param params {Object} - Query options.
+ *        limit {Number} - Restrict to this many entries.
+ *        offset {Number} - Return servers from this point onwards.
+ *        raw {Boolean} - Return the raw moray server entries (not Models).
  */
 
 ModelServer.list = function (params, callback) {
     assert.optionalNumber(params.limit, 'params.limit');
     assert.optionalNumber(params.offset, 'params.offset');
+    assert.optionalBool(params.raw, 'params.raw');
 
     var self = this;
 
@@ -286,6 +292,11 @@ ModelServer.list = function (params, callback) {
     }
 
     function _onEnd() {
+        if (params.raw) {
+            callback(null, servers);
+            return;
+        }
+
         async.map(
             servers,
             function (server, cb) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cnapi",
   "description": "Triton Compute Node API",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
On CNAPI startup, this loads the stored (in moray) cnapi_status entries, which are used as the base for the heartbeat entries (i.e. what we saw before is what we know now).

I also added a second check, to load any cnapi_servers entries which are currently in state 'running' and have not heartbeated (i.e. those servers which do not have a cnapi_status entry) - just in case there are some old server entries around (or if the cnapi_status table was wiped).