### PR TITLE
TRITON-406 want clearer error message when a provision fails during DAPI server allocation

### DIFF
--- a/lib/endpoints/allocations.js
+++ b/lib/endpoints/allocations.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -231,14 +231,32 @@ Allocations.allocate = function handlerAllocationsAllocate(req, res, next) {
                         return;
                     }
 
+                    var failed = stepSummary.slice(-1)[0];
+
                     // XXX we need a better way of determining which step in
                     // particular we were on when the sequence came to an end
-                    if (stepSummary.slice(-1)[0].step === VOLUMES_MSG) {
+                    if (failed.step === VOLUMES_MSG) {
                         cb(new errors.VolumeServerNoResourcesError());
                         return;
                     }
 
-                    cb(new errors.NoAllocatableServersError());
+                    // Grab the reason for the last step that resulted in no
+                    // servers being left.
+                    var reason = failed.reasons['*'];
+                    if (!reason) {
+                        var stepName = failed.step || '';
+                        // Uncapitalize the step name.
+                        stepName = stepName[0].toLowerCase() +
+                            stepName.slice(1);
+                        // Convert 'servers ...' to 'no servers ...' - this is
+                        // to make the error message more readable.
+                        if (stepName.slice(0, 8) === 'servers ') {
+                            stepName = 'no ' + stepName;
+                        }
+                        reason = stepName;
+                    }
+
+                    cb(new errors.NoAllocatableServersError(reason));
                     return;
                 });
             }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -135,11 +135,11 @@ NotImplementedError.description =
 
 
 
-function NoAllocatableServersError() {
+function NoAllocatableServersError(msg) {
     _CnapiBaseError.call(this, {
         restCode: this.constructor.restCode,
         statusCode: this.constructor.statusCode,
-            message: 'No compute resources available'
+            message: 'No compute resources available' + (msg ? ': ' + msg : '')
         });
 }
 util.inherits(NoAllocatableServersError, _CnapiBaseError);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cnapi",
   "description": "Triton Compute Node API",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This will add extra message info to NoAllocatableServersError.

For example, it will look like this:
```
$ triton create base-64 sample-256M-traits-different
triton instance create: error: error creating instance: No compute resources available: no servers with correct traits

# sdc-vmapi /vms -X POST -d@no_cpu_cap.json
{
  "code": "NoAllocatableServersError",
  "message": "No compute resources available: no servers which have same existence of cpu_cap as package"
}
```
