### PR TITLE
TRITON-2224 use single exchange rather than per-execute exchange

### DIFF
--- a/lib/ur.js
+++ b/lib/ur.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
 /*

--- a/lib/ur.js
+++ b/lib/ur.js
@@ -54,6 +54,9 @@ Ur.prototype.bindQueues = function () {
                 self.emit('serverSysinfo', message, deliveryInfo.routingKey);
             }
         });
+
+        self.exchange = self.connection.exchange('amq.topic');
+        self.log.info('created topic exchange');
     });
 
     q.on('error', function () {
@@ -110,13 +113,12 @@ Ur.prototype.execute = function (opts, callback) {
             ctag = ok.consumerTag;
             queue.bind('ur.execute-reply.' + uuid + '.' + reqid,
                 function () {
-                    exchange.publish(
+                    self.exchange.publish(
                         'ur.execute.' + uuid + '.' + reqid,
                         message);
                 });
         });
 
-        var exchange = self.connection.exchange('amq.topic');
         timeout = setTimeout(function () {
             queue.unsubscribe(ctag);
             setTimeout(function () {

--- a/lib/ur.js
+++ b/lib/ur.js
@@ -55,7 +55,7 @@ Ur.prototype.bindQueues = function () {
             }
         });
 
-        self.exchange = self.connection.exchange('amq.topic');
+        self.topicExchange = self.connection.exchange('amq.topic');
         self.log.info('created topic exchange');
     });
 
@@ -113,7 +113,7 @@ Ur.prototype.execute = function (opts, callback) {
             ctag = ok.consumerTag;
             queue.bind('ur.execute-reply.' + uuid + '.' + reqid,
                 function () {
-                    self.exchange.publish(
+                    self.topicExchange.publish(
                         'ur.execute.' + uuid + '.' + reqid,
                         message);
                 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cnapi",
   "description": "Triton Compute Node API",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Without this patch, CNAPI will crash when it receives too many calls to execute things via Ur. This includes:

```
GET /platforms?os=true
```

calls. Once the number of "channels" in the amqp library are exhausted (65535) it will crash.

With this patch, we are no longer leaving extra exchanges in the connection.channels, so it does not exhibit this problem.